### PR TITLE
chore: track avendish 558744d

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -102,7 +102,7 @@ endif()
 FetchContent_Declare(
   avendish
   GIT_REPOSITORY "https://github.com/celtera/avendish"
-  GIT_TAG main
+  GIT_TAG 558744dcd18657163a1d6955ed9992188e00e8ad
   GIT_PROGRESS true
 )
 FetchContent_Populate(avendish)


### PR DESCRIPTION
## What

Track the latest Avendish `main` (`celtera/avendish@558744d`), pinned instead of
floating `main`.

## Notes

- `avnd_create_max_package` now bundles the generated Max help patch, so the
  existing package gains it for free.
- CI is deliberately left as-is: ultraleap requires a tokened private
  `celtera/LeapSDK` checkout + LeapC runtime bundling + codesign, which the shared
  `avnd-addon.yml` cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
